### PR TITLE
remove object type check

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,6 +1,9 @@
 name: tests
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     types:
       - opened

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,5 +22,10 @@ jobs:
       - name: Install npm dependencies
         run: npm ci --ignore-scripts --no-audit --no-fund
 
+      - name: Set Git identity
+        run: |
+          git config --global user.name "tests"
+          git config --global user.email "tests@bwatkins.dev"
+
       - name: Run tests
         run: npm test

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -53,16 +53,11 @@ export const lint = async (
       continue;
     }
 
-    const cmd = execFile('git', ['-C', path, 'cat-file', '-t', trimmed], {
-      encoding: 'utf8',
-    });
-
     let issue;
     try {
-      const stdout = (await cmd).stdout.trim();
-      if (stdout !== 'commit') {
-        issue = `found ${stdout} not commit (${trimmed})`;
-      }
+      await execFile('git', ['-C', path, 'cat-file', '-t', trimmed], {
+        encoding: 'utf8',
+      });
     } catch (error) {
       issue = `not found in repository (${trimmed})`;
     }


### PR DESCRIPTION
Remnant from before checking that every non-comment entry is an abbreviated SHA-1 as specified in [the skip-list documentation](https://git-scm.com/docs/git-fsck#Documentation/git-fsck.txt-fsckskipList). Now that it must be a full SHA-1, we can piggy back off the protections Git has in-place for retrieving ambiguous references with `cat-file`.